### PR TITLE
Fix docker-compose config for Codespaces

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,38 +1,38 @@
 version: '3.7'
 services:
-  # Update this to the name of the service you want to work with in your docker-compose.yml file
-  yuela:
-    # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
-    # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks,
-    # debugging) to execute as the user. Uncomment the next line if you want the entire
-    # container to run as this user instead. Note that, on Linux, you may need to
-    # ensure the UID and GID of the container user you create matches your local user.
-    # See https://aka.ms/vscode-remote/containers/non-root for details.
-    #
-    # user: vscode
+    # Update this to the name of the service you want to work with in your docker-compose.yml file
+    yuela:
+        # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
+        # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks,
+        # debugging) to execute as the user. Uncomment the next line if you want the entire
+        # container to run as this user instead. Note that, on Linux, you may need to
+        # ensure the UID and GID of the container user you create matches your local user.
+        # See https://aka.ms/vscode-remote/containers/non-root for details.
+        #
+        # user: vscode
 
-    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer
-    # folder. Note that the path of the Dockerfile and context is relative to the *primary*
-    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
-    # array). The sample below assumes your primary file is in the root of your project.
-    #
-    # build:
-    #   context: .
-    #   dockerfile: .devcontainer/Dockerfile
+        # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer
+        # folder. Note that the path of the Dockerfile and context is relative to the *primary*
+        # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+        # array). The sample below assumes your primary file is in the root of your project.
+        #
+        # build:
+        #   context: .
+        #   dockerfile: .devcontainer/Dockerfile
 
-    volumes:
-      # Update this to wherever you want VS Code to mount the folder of your project
-      - .:/app:cached
+        volumes:
+            # Update this to wherever you want VS Code to mount the folder of your project
+            - .:/app:cached
 
-      # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
-      # - /var/run/docker.sock:/var/run/docker.sock
+            # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
+            # - /var/run/docker.sock:/var/run/docker.sock
 
-    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
-    # cap_add:
-    #   - SYS_PTRACE
-    # security_opt:
-    #   - seccomp:unconfined
+        # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+        # cap_add:
+        #   - SYS_PTRACE
+        # security_opt:
+        #   - seccomp:unconfined
 
-    # Overrides default command so things don't shut down after the process ends.
-    command: /bin/sh -c "while sleep 1000; do :; done"
-
+        # Overrides default command so things don't shut down after the process ends.
+        command: ''
+        entrypoint: ['/bin/sh', '-c', 'while sleep 1000; do :; done']


### PR DESCRIPTION
The previous config caused the container to exit soon after starting since the Dockerfile includes both an entrypoint and a command. The entrypoint script did not run indefinitely, so it was causing the container to stop once it exited.

To fix this, the compose configuration for Codespaces can override both the command and entrypoint and change the entrypoint to run indefinitely, which keeps the container running and available for connections.

I verified this change by opening a codespace on this branch and confirmed it did not exit.